### PR TITLE
fix local provider bug

### DIFF
--- a/are/simulation/agents/llm/litellm/litellm_engine.py
+++ b/are/simulation/agents/llm/litellm/litellm_engine.py
@@ -103,7 +103,7 @@ Action:
             provider = (
                 self.model_config.provider
                 if self.model_config.provider != "local"
-                else None
+                else "hosted_vllm"
             )
 
             response = completion(


### PR DESCRIPTION
**PR Description**
When the provider is set to `local`, the `model` name can be arbitrary. In such cases, `litellm` may enter the following code path:
https://github.com/BerriAI/litellm/blob/67b0c874a376a121f53f578e964992960757cfa5/litellm/litellm_core_utils/get_llm_provider_logic.py#L386-L393


This results in the following error:

```
LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed model={model}
Pass model as E.g. For 'Huggingface' inference endpoints pass in 
completion(model='huggingface/starcoder',..)
Learn more: https://docs.litellm.ai/docs/providers
```

**Fix**
To handle this scenario, I updated the provider resolution logic to use:

```python
      provider = (
          self.model_config.provider
          if self.model_config.provider != "local"
          else "hosted_vllm"
      )
```

This ensures that when `provider="local"`, `litellm` correctly falls back to `"hosted_vllm"` and avoids the error.