### PR TITLE
cache the fallbackfs access to remote fs

### DIFF
--- a/are/simulation/apps/utils/cached_remote_filesystem.py
+++ b/are/simulation/apps/utils/cached_remote_filesystem.py
@@ -1,0 +1,213 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+
+import logging
+import os
+from typing import Any
+
+from are.simulation.apps.utils.remote_fs_cache import get_remote_fs_cache
+
+from fsspec import AbstractFileSystem
+from fsspec.spec import AbstractBufferedFile
+
+logger = logging.getLogger(__name__)
+
+
+class CachedRemoteFileSystem(AbstractFileSystem):
+    """
+    A filesystem wrapper that caches listings and stats for remote filesystems.
+
+    This filesystem wraps any fsspec filesystem and provides global caching
+    for file listings and stats. It's designed to reduce API calls to remote
+    filesystems (e.g., S3, HuggingFace) when running multiple scenarios that
+    share the same remote path.
+
+    The cache is global and thread-safe, shared across all instances of this
+    filesystem with the same remote URI.
+
+    Key Features:
+        * Global caching of file listings (from find() calls)
+        * Global caching of file stats (size, mode) loaded lazily
+        * Thread-safe cache shared across all instances
+        * Transparent pass-through for all other operations
+    """
+
+    def __init__(
+        self,
+        fs: AbstractFileSystem,
+        remote_uri: str,
+        **kwargs: Any,
+    ):
+        """
+        Initialize the CachedRemoteFileSystem.
+
+        :param fs: The underlying remote filesystem to wrap
+        :param remote_uri: The URI of the remote filesystem (for cache key)
+        :param kwargs: Additional arguments to pass to AbstractFileSystem
+        """
+        super().__init__(**kwargs)
+        self.remote_uri = remote_uri
+        self.cache = get_remote_fs_cache()
+
+        # Extract root path from URI
+        # For "mock://remote" the root should be "/remote"
+        if "://" in remote_uri:
+            root = "/" + remote_uri.split("://", 1)[1]
+        else:
+            root = remote_uri if remote_uri.startswith("/") else "/" + remote_uri
+
+        # Pre-populate metadata cache on initialization
+        # Pass the filesystem directly to avoid URL resolution
+        self.cache.get_or_create_fs_entry(self.remote_uri, fs=fs, root=root)
+
+        # Get the shared cached filesystem from the global cache
+        # This ensures all instances with the same remote_uri share
+        # the same file cache, avoiding redundant downloads
+        self.fs = self.cache.get_cached_filesystem(remote_uri)
+
+        logger.debug(f"Initialized CachedRemoteFileSystem for {remote_uri}")
+
+    def find(
+        self, path: str, maxdepth: int | None = None, withdirs: bool = False, **kwargs
+    ) -> list[str]:
+        """
+        List all files below path using cached data when possible.
+
+        :param path: The path to search from
+        :param maxdepth: Maximum depth to search
+        :param withdirs: Include directories in results
+        :param kwargs: Additional arguments
+        :return: List of file paths
+        """
+        # Get cached data (doesn't call find() again if already cached)
+        if self.remote_uri in self.cache._cache:
+            entry = self.cache._cache[self.remote_uri]
+            root = entry["root"]
+            cached_files = entry["file_list"]
+
+            # Convert cached relative paths to absolute paths
+            result = []
+            for rel_path in cached_files:
+                abs_path = os.path.join(root, rel_path.lstrip("/"))
+                # Filter by path prefix if specified
+                if abs_path.startswith(path):
+                    result.append(abs_path)
+
+            logger.debug(f"find() returned {len(result)} cached files for {path}")
+            return result
+        else:
+            # Fall back to underlying filesystem if not cached
+            return self.fs.find(path, maxdepth=maxdepth, withdirs=withdirs, **kwargs)
+
+    def ls(
+        self, path: str, detail: bool = True, **kwargs: Any
+    ) -> list[dict[str, Any]] | list[str]:
+        """
+        List directory contents, with optional caching of stats.
+
+        :param path: Path to list
+        :param detail: If True, return detailed information
+        :param kwargs: Additional arguments
+        :return: List of files/directories
+        """
+        # Use the underlying filesystem for ls
+        results = self.fs.ls(path, detail=detail, **kwargs)
+
+        if detail:
+            # Cache stats for files
+            for item in results:
+                if isinstance(item, dict) and item.get("type") == "file":
+                    try:
+                        # Get relative path for caching
+                        _, root, _ = self.cache.get_or_create_fs_entry(self.remote_uri)
+                        rel_path = "/" + os.path.relpath(item["name"], root)
+
+                        # Cache the stats
+                        self.cache.set_file_stats(
+                            self.remote_uri,
+                            rel_path,
+                            item.get("size", 0),
+                            item.get("mode", 0o644),
+                        )
+                    except Exception as e:
+                        logger.debug(f"Failed to cache stats for {item['name']}: {e}")
+
+        return results
+
+    def info(self, path: str, **kwargs: Any) -> dict[str, Any]:
+        """
+        Get file info, using cached stats when available.
+
+        :param path: Path to get info for
+        :param kwargs: Additional arguments
+        :return: File info dictionary
+        """
+        # Try to get cached stats first
+        try:
+            _, root, _ = self.cache.get_or_create_fs_entry(self.remote_uri)
+            rel_path = "/" + os.path.relpath(path, root)
+            cached_stats = self.cache.get_file_stats(self.remote_uri, rel_path)
+
+            if cached_stats:
+                # We have cached stats, but we still need other metadata
+                # Get full info from filesystem
+                info = self.fs.info(path, **kwargs)
+
+                # Update with cached stats (avoid re-fetching if expensive)
+                info["size"] = cached_stats["size"]
+                info["mode"] = cached_stats["mode"]
+
+                logger.debug(f"Used cached stats for {path}")
+                return info
+        except Exception as e:
+            logger.debug(f"Failed to use cached stats for {path}: {e}")
+
+        # Fall back to direct filesystem call
+        info = self.fs.info(path, **kwargs)
+
+        # Cache the stats for future use
+        try:
+            _, root, _ = self.cache.get_or_create_fs_entry(self.remote_uri)
+            rel_path = "/" + os.path.relpath(path, root)
+            self.cache.set_file_stats(
+                self.remote_uri, rel_path, info.get("size", 0), info.get("mode", 0o644)
+            )
+        except Exception as e:
+            logger.debug(f"Failed to cache stats for {path}: {e}")
+
+        return info
+
+    # Proxy all other methods to the underlying filesystem
+    def __getattr__(self, attr: str) -> Any:
+        """Proxy all other methods to the underlying filesystem."""
+        return getattr(self.fs, attr)
+
+    def open(
+        self,
+        path: str,
+        mode: str = "rb",
+        block_size: int | None = None,
+        cache_options: dict | None = None,
+        **kwargs: Any,
+    ) -> AbstractBufferedFile:
+        """
+        Open a file.
+
+        :param path: Path to open
+        :param mode: Mode to open in
+        :param block_size: Block size for reading
+        :param cache_options: Cache options
+        :param kwargs: Additional arguments
+        :return: File handle
+        """
+        return self.fs.open(
+            path,
+            mode=mode,
+            block_size=block_size,
+            cache_options=cache_options,
+            **kwargs,
+        )

--- a/are/simulation/apps/utils/fallback_file_system.py
+++ b/are/simulation/apps/utils/fallback_file_system.py
@@ -231,15 +231,20 @@ class FallbackFileSystem(AbstractFileSystem):
             expected_paths = set()
             # If fallback_root exists, scan it to find all potential paths
             if self.fallback_root and self.fallback_fs.exists(self.fallback_root):
-                for path_info in self.fallback_fs.find(
+                found_paths = self.fallback_fs.find(
                     self.fallback_root, withdirs=True, detail=False
-                ):
-                    # Get the path relative to fallback_root
-                    rel_path = os.path.relpath(path_info, self.fallback_root)
-                    if rel_path == ".":
-                        continue
-                    rel_path = "/" + rel_path
-                    expected_paths.add(rel_path)
+                )
+                # Ensure we're working with a list of strings
+                if isinstance(found_paths, list):
+                    for path_info in found_paths:
+                        # path_info should be a string when detail=False
+                        if isinstance(path_info, str):
+                            # Get the path relative to fallback_root
+                            rel_path = os.path.relpath(path_info, self.fallback_root)
+                            if rel_path == ".":
+                                continue
+                            rel_path = "/" + rel_path
+                            expected_paths.add(rel_path)
 
         # Check for conflicts - non-empty files in the underlying filesystem
         # that would be overwritten by the fallback

--- a/are/simulation/apps/utils/fallback_file_system.py
+++ b/are/simulation/apps/utils/fallback_file_system.py
@@ -117,12 +117,14 @@ class FallbackFileSystem(AbstractFileSystem):
                             fallback_path
                         ) and self.fallback_fs.isfile(fallback_path):
                             info = self.fallback_fs.info(fallback_path)
+
                             # Update the registry with actual stats
                             self.fallback_stats[rel_path] = LoadedFallbackEntry(
                                 size=info["size"],
                                 mode=info.get("mode", DEFAULT_MODE),
                                 loaded=True,
                             )
+
                             logger.debug(f"Lazy loaded stats for {rel_path}")
                         else:
                             # File doesn't exist in fallback, remove from registry
@@ -204,7 +206,22 @@ class FallbackFileSystem(AbstractFileSystem):
                            would be overwritten by the fallback
         """
         # Parse the fallback_root URI to get a filesystem and path
-        self.fallback_fs, self.fallback_root = url_to_fs(fallback_root)
+        raw_fs, self.fallback_root = url_to_fs(fallback_root)
+
+        # Wrap remote filesystems with CachedRemoteFileSystem for performance
+        if "://" in fallback_root:
+            # This is a remote filesystem - wrap it with caching
+            from are.simulation.apps.utils.cached_remote_filesystem import (
+                CachedRemoteFileSystem,
+            )
+
+            self.fallback_fs = CachedRemoteFileSystem(raw_fs, fallback_root)
+            logger.info(
+                f"Wrapped remote filesystem {fallback_root} with CachedRemoteFileSystem"
+            )
+        else:
+            # Local filesystem - use as-is
+            self.fallback_fs = raw_fs
 
         assert self.fallback_fs is not None
         assert self.fallback_root is not None
@@ -276,7 +293,7 @@ class FallbackFileSystem(AbstractFileSystem):
         if self.fallback_root is None or self.fallback_fs is None:
             return
 
-        # Phase 1: Lightweight discovery - use find() to get all existing files in one call
+        # Phase 1: Lightweight discovery - use find() to get all existing files
         try:
             all_paths = self.fallback_fs.find(
                 self.fallback_root, withdirs=True, detail=False

--- a/are/simulation/apps/utils/remote_fs_cache.py
+++ b/are/simulation/apps/utils/remote_fs_cache.py
@@ -1,0 +1,206 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+
+import logging
+import os
+import tempfile
+import threading
+from typing import Any
+
+from fsspec import AbstractFileSystem
+from fsspec.core import url_to_fs
+from fsspec.implementations.cached import WholeFileCacheFileSystem
+
+logger = logging.getLogger(__name__)
+
+
+class RemoteFsCache:
+    """
+    A global cache for remote filesystem listings and file stats.
+
+    This cache is designed to reduce the number of calls to remote filesystems
+    (e.g., S3, HuggingFace) when running multiple scenarios that share the same
+    remote filesystem path. It caches:
+
+    1. File/directory listings (from find() calls)
+    2. File stats (size, mode) loaded lazily
+
+    The cache is thread-safe and shared across all FallbackFileSystem instances.
+    """
+
+    def __init__(self):
+        self._lock = threading.RLock()
+        # Cache structure:
+        # {
+        #   "remote_uri": {
+        #     "fs": AbstractFileSystem,  # Raw filesystem
+        #     "cached_fs": WholeFileCacheFileSystem,  # Cached filesystem wrapper
+        #     "root": str,
+        #     "file_list": set[str],  # Set of relative paths
+        #     "stats": {  # Cached stats for individual files
+        #       "relative_path": {"size": int, "mode": int}
+        #     }
+        #   }
+        # }
+        self._cache: dict[str, dict[str, Any]] = {}
+        self._cache_storage = os.path.join(tempfile.gettempdir(), "are_remote_fs_cache")
+
+    def get_or_create_fs_entry(
+        self,
+        remote_uri: str,
+        fs: AbstractFileSystem | None = None,
+        root: str | None = None,
+    ) -> tuple[AbstractFileSystem, str, set[str]]:
+        """
+        Get or create a cache entry for the given remote URI.
+
+        Returns a tuple of (filesystem, root_path, file_list).
+        If the entry doesn't exist, it will be created by scanning the remote filesystem.
+
+        :param remote_uri: The remote filesystem URI (e.g., "s3://bucket/path" or "hf://...")
+        :param fs: Optional filesystem instance (if None, will be resolved from URI)
+        :param root: Optional root path (if None, will be resolved from URI)
+        :return: Tuple of (filesystem, root_path, set of relative paths)
+        """
+        with self._lock:
+            if remote_uri in self._cache:
+                entry = self._cache[remote_uri]
+                return entry["fs"], entry["root"], entry["file_list"]
+
+            # Create new entry
+            logger.info(f"Initializing remote filesystem cache for: {remote_uri}")
+
+            # Use provided fs/root or resolve from URI
+            if fs is None or root is None:
+                fs, root = url_to_fs(remote_uri)
+
+            # Scan the remote filesystem once to get all files
+            file_list = set()
+            try:
+                if fs.exists(root):
+                    all_paths = fs.find(root, withdirs=True, detail=False)
+                    for path_info in all_paths:
+                        rel_path = "/" + os.path.relpath(path_info, root)
+                        if rel_path != "/.":
+                            file_list.add(rel_path)
+                    logger.info(
+                        f"Cached {len(file_list)} files from remote filesystem: {remote_uri}"
+                    )
+                else:
+                    logger.warning(f"Remote path does not exist: {remote_uri}")
+            except Exception as e:
+                logger.error(
+                    f"Failed to scan remote filesystem {remote_uri}: {e}", exc_info=True
+                )
+
+            # Store in cache
+            self._cache[remote_uri] = {
+                "fs": fs,
+                "root": root,
+                "file_list": file_list,
+                "stats": {},
+            }
+
+            return fs, root, file_list
+
+    def get_file_stats(self, remote_uri: str, rel_path: str) -> dict[str, Any] | None:
+        """
+        Get cached file stats for a relative path, or None if not cached.
+
+        :param remote_uri: The remote filesystem URI
+        :param rel_path: The relative path (e.g., "/path/to/file")
+        :return: Dict with "size" and "mode" keys, or None if not cached
+        """
+        with self._lock:
+            if remote_uri not in self._cache:
+                return None
+            return self._cache[remote_uri]["stats"].get(rel_path)
+
+    def set_file_stats(
+        self, remote_uri: str, rel_path: str, size: int, mode: int
+    ) -> None:
+        """
+        Cache file stats for a relative path.
+
+        :param remote_uri: The remote filesystem URI
+        :param rel_path: The relative path (e.g., "/path/to/file")
+        :param size: File size in bytes
+        :param mode: File mode (permissions)
+        """
+        with self._lock:
+            if remote_uri not in self._cache:
+                logger.warning(
+                    f"Attempted to cache stats for uninitialized URI: {remote_uri}"
+                )
+                return
+            self._cache[remote_uri]["stats"][rel_path] = {"size": size, "mode": mode}
+
+    def clear(self) -> None:
+        """Clear all cached data."""
+        with self._lock:
+            # Clear the in-memory cache
+            # Note: WholeFileCacheFileSystem disk cache persists
+            self._cache.clear()
+            logger.info("Cleared remote filesystem cache")
+
+    def get_cached_filesystem(self, remote_uri: str) -> AbstractFileSystem:
+        """
+        Get a cached filesystem for the given remote URI.
+
+        This returns a WholeFileCacheFileSystem that wraps the raw filesystem,
+        providing file content caching. The cached filesystem is shared across
+        all callers for the same remote URI.
+
+        :param remote_uri: The remote filesystem URI
+        :return: Cached filesystem instance
+        """
+        with self._lock:
+            # Ensure the cache entry exists
+            self.get_or_create_fs_entry(remote_uri)
+
+            # Check if we already have a cached filesystem
+            if "cached_fs" in self._cache[remote_uri]:
+                return self._cache[remote_uri]["cached_fs"]
+
+            # Create a new cached filesystem
+            raw_fs = self._cache[remote_uri]["fs"]
+            cached_fs = WholeFileCacheFileSystem(
+                fs=raw_fs,
+                cache_storage=self._cache_storage,
+            )
+            self._cache[remote_uri]["cached_fs"] = cached_fs
+
+            logger.info(
+                f"Created shared cached filesystem for {remote_uri} "
+                f"at {self._cache_storage}"
+            )
+
+            return cached_fs
+
+    def get_cache_stats(self) -> dict[str, dict[str, int]]:
+        """
+        Get statistics about the cache contents.
+
+        :return: Dict mapping URIs to stats like file count and cached stats count
+        """
+        with self._lock:
+            stats = {}
+            for uri, entry in self._cache.items():
+                stats[uri] = {
+                    "file_count": len(entry["file_list"]),
+                    "cached_stats_count": len(entry["stats"]),
+                }
+            return stats
+
+
+# Global singleton instance
+_global_cache = RemoteFsCache()
+
+
+def get_remote_fs_cache() -> RemoteFsCache:
+    """Get the global RemoteFsCache instance."""
+    return _global_cache

--- a/are/simulation/scenarios/scenario_imported_from_json/utils.py
+++ b/are/simulation/scenarios/scenario_imported_from_json/utils.py
@@ -385,8 +385,8 @@ def preprocess_scenario_from_config(
         judge_config = None
         if config.judge_engine_config is not None:
             from are.simulation.validation.configs import (
-                create_judge_engine,
                 GraphPerEventJudgeConfig,
+                create_judge_engine,
             )
 
             judge_engine = create_judge_engine(config.judge_engine_config)

--- a/are/simulation/tests/apps/cached_remote_filesystem_test.py
+++ b/are/simulation/tests/apps/cached_remote_filesystem_test.py
@@ -1,0 +1,432 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+
+import threading
+from pathlib import Path
+from typing import Any
+from unittest.mock import call, MagicMock
+
+import fsspec
+import pytest
+
+from are.simulation.apps.utils.cached_remote_filesystem import CachedRemoteFileSystem
+from are.simulation.apps.utils.remote_fs_cache import get_remote_fs_cache
+
+
+class MockFileSystem(fsspec.AbstractFileSystem):
+    """
+    Mock filesystem that tracks access counts for testing.
+    """
+
+    def __init__(self, files: dict[str, str | bytes], **kwargs: Any):
+        super().__init__(**kwargs)
+        self.files = files  # {path: content}
+        self.find_count = 0
+        self.ls_count = 0
+        self.info_count = 0
+        self.open_count = 0
+        self.exists_count = 0
+
+    def find(
+        self, path: str, maxdepth: int | None = None, withdirs: bool = False, **kwargs
+    ) -> list[str]:
+        self.find_count += 1
+        # Return all files under the path
+        result = [p for p in self.files.keys() if p.startswith(path)]
+        return result
+
+    def ls(
+        self, path: str, detail: bool = True, **kwargs: Any
+    ) -> list[dict[str, Any]] | list[str]:
+        self.ls_count += 1
+        # Return files in the directory
+        items = []
+        for file_path, content in self.files.items():
+            if file_path.startswith(path) and file_path != path:
+                if detail:
+                    items.append(
+                        {
+                            "name": file_path,
+                            "size": (
+                                len(content) if isinstance(content, (str, bytes)) else 0
+                            ),
+                            "type": "file",
+                            "mode": 0o644,
+                        }
+                    )
+                else:
+                    items.append(file_path)
+        return items
+
+    def info(self, path: str, **kwargs: Any) -> dict[str, Any]:
+        self.info_count += 1
+        if path not in self.files:
+            raise FileNotFoundError(f"File not found: {path}")
+        content = self.files[path]
+        return {
+            "name": path,
+            "size": len(content) if isinstance(content, (str, bytes)) else 0,
+            "type": "file",
+            "mode": 0o644,
+        }
+
+    def open(self, path: str, mode: str = "rb", **kwargs: Any):
+        self.open_count += 1
+        if path not in self.files:
+            raise FileNotFoundError(f"File not found: {path}")
+        content = self.files[path]
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+        # Return a simple BytesIO-like object
+        from io import BytesIO
+
+        return BytesIO(content)
+
+    def exists(self, path: str, **kwargs: Any) -> bool:
+        self.exists_count += 1
+        # A path exists if it's a file or if any file starts with it (directory)
+        if path in self.files:
+            return True
+        # Check if this is a directory (any file starts with path/)
+        path_with_slash = path if path.endswith("/") else path + "/"
+        return any(p.startswith(path_with_slash) for p in self.files.keys())
+
+    def isfile(self, path: str) -> bool:
+        return path in self.files
+
+    def isdir(self, path: str) -> bool:
+        # Simple check: if any file starts with this path, it's a "directory"
+        return any(
+            p.startswith(path + "/") or p.startswith(path) for p in self.files.keys()
+        )
+
+
+@pytest.fixture
+def mock_files():
+    """Test files for the mock filesystem."""
+    return {
+        "/remote/test1.txt": "Content of test1",
+        "/remote/test2.txt": "Content of test2",
+        "/remote/dir/test3.txt": "Content of test3",
+        "/remote/dir/test4.txt": "Content of test4",
+    }
+
+
+@pytest.fixture(scope="function", autouse=True)
+def isolated_cache():
+    """Ensure each test in this module has an isolated cache."""
+    # Clear before the test
+    get_remote_fs_cache().clear()
+    yield
+    # Clear after the test
+    get_remote_fs_cache().clear()
+
+
+def test_cached_remote_filesystem_find_called_once(mock_files):
+    """Test that find() is only called once on the underlying filesystem."""
+    # Create mock filesystem
+    mock_fs = MockFileSystem(mock_files)
+
+    # Create two CachedRemoteFileSystem instances with the same URI
+    uri = "mock://remote"
+    cached_fs1 = CachedRemoteFileSystem(mock_fs, uri)
+    cached_fs2 = CachedRemoteFileSystem(mock_fs, uri)
+
+    # Verify find was called only once during initialization
+    assert mock_fs.find_count == 1
+
+    # Call find() on both instances
+    result1 = cached_fs1.find("/remote")
+    result2 = cached_fs2.find("/remote")
+
+    # Verify find was still only called once (uses cache)
+    assert mock_fs.find_count == 1
+
+    # Verify results are correct
+    assert len(result1) == len(mock_files)
+    assert len(result2) == len(mock_files)
+
+
+def test_cached_remote_filesystem_info_caching(mock_files):
+    """Test that info() returns correct and consistent results."""
+    # Create mock filesystem
+    mock_fs = MockFileSystem(mock_files)
+
+    # Create CachedRemoteFileSystem
+    uri = "mock://remote"
+    cached_fs = CachedRemoteFileSystem(mock_fs, uri)
+
+    # Call info() on a file
+    info1 = cached_fs.info("/remote/test1.txt")
+
+    # Call info() again on the same file
+    info2 = cached_fs.info("/remote/test1.txt")
+
+    # Both calls should return correct and consistent info
+    assert info1["size"] == info2["size"]
+    assert info1["mode"] == info2["mode"]
+    assert info1["size"] == len(mock_files["/remote/test1.txt"])
+
+
+def test_cached_remote_filesystem_ls_caching(mock_files):
+    """Test that ls() caches file stats."""
+    # Create mock filesystem
+    mock_fs = MockFileSystem(mock_files)
+
+    # Create CachedRemoteFileSystem
+    uri = "mock://remote"
+    cached_fs = CachedRemoteFileSystem(mock_fs, uri)
+
+    # Call ls with detail=True
+    ls_result = cached_fs.ls("/remote", detail=True)
+
+    # Verify we got results
+    assert len(ls_result) > 0
+
+    # Now call info() on files that were listed
+    for item in ls_result:
+        if isinstance(item, dict):
+            file_path = item["name"]
+            # Get cache to verify stats were cached
+            cache = get_remote_fs_cache()
+            rel_path = "/" + file_path.replace("/remote/", "")
+            cached_stats = cache.get_file_stats(uri, rel_path)
+            # Stats should be cached from ls() call
+            if cached_stats:
+                assert cached_stats["size"] == item["size"]
+
+
+def test_cached_remote_filesystem_shared_cache_across_instances():
+    """Test that multiple instances share the same cache."""
+    # Use a fresh mock filesystem for this test
+    test_files = {
+        "/test/file1.txt": "Content 1",
+        "/test/file2.txt": "Content 2",
+    }
+    mock_fs = MockFileSystem(test_files)
+
+    # Create three CachedRemoteFileSystem instances with the same URI
+    uri = "mock://test"
+
+    cached_fs1 = CachedRemoteFileSystem(mock_fs, uri)
+    count_after_first = mock_fs.find_count
+
+    cached_fs2 = CachedRemoteFileSystem(mock_fs, uri)
+    cached_fs3 = CachedRemoteFileSystem(mock_fs, uri)
+
+    # The cache should be shared, so find should not be called again for fs2 and fs3
+    assert mock_fs.find_count == count_after_first
+
+    # Call find on all instances - should use cached data
+    result1 = cached_fs1.find("/test")
+    result2 = cached_fs2.find("/test")
+    result3 = cached_fs3.find("/test")
+
+    # find() calls should use cached data, not call underlying fs
+    assert mock_fs.find_count == count_after_first
+
+    # All results should be identical
+    assert result1 == result2 == result3
+    assert len(result1) == len(test_files)
+
+
+def test_cached_remote_filesystem_file_content_caching(mock_files):
+    """Test that file content is cached and shared across instances."""
+    # Create mock filesystem
+    mock_fs = MockFileSystem(mock_files)
+
+    # Create two CachedRemoteFileSystem instances with the same URI
+    uri = "mock://remote"
+    cached_fs1 = CachedRemoteFileSystem(mock_fs, uri)
+    cached_fs2 = CachedRemoteFileSystem(mock_fs, uri)
+
+    initial_open_count = mock_fs.open_count
+
+    # Open a file with the first instance
+    with cached_fs1.open("/remote/test1.txt", "rb") as f:
+        content1 = f.read()
+
+    first_open_count = mock_fs.open_count - initial_open_count
+
+    # Open the same file with the second instance
+    with cached_fs2.open("/remote/test1.txt", "rb") as f:
+        content2 = f.read()
+
+    second_open_count = mock_fs.open_count - initial_open_count
+
+    # Content should be the same
+    assert content1 == content2
+
+    # Because they share the same WholeFileCacheFileSystem,
+    # the second open should use the cached file
+    # (Note: This depends on WholeFileCacheFileSystem behavior)
+    # At minimum, verify content is correct
+    assert content1.decode("utf-8") == "Content of test1"
+
+
+def test_cached_remote_filesystem_thread_safety():
+    """Test that the cache is thread-safe."""
+    # Use a fresh mock filesystem for this test
+    test_files = {
+        "/thread_test/file1.txt": "Content 1",
+        "/thread_test/file2.txt": "Content 2",
+    }
+    mock_fs = MockFileSystem(test_files)
+    uri = "mock://thread_test"
+
+    results = []
+    errors = []
+
+    def worker():
+        try:
+            # Each thread creates its own CachedRemoteFileSystem instance
+            cached_fs = CachedRemoteFileSystem(mock_fs, uri)
+            # Call find()
+            result = cached_fs.find("/thread_test")
+            results.append(result)
+        except Exception as e:
+            errors.append(e)
+
+    # Create multiple threads
+    threads = [threading.Thread(target=worker) for _ in range(10)]
+
+    # Start all threads
+    for thread in threads:
+        thread.start()
+
+    # Wait for all threads to complete
+    for thread in threads:
+        thread.join()
+
+    # Verify no errors occurred
+    assert len(errors) == 0
+
+    # Verify all threads got results
+    assert len(results) == 10
+
+    # Verify all results are identical
+    first_result = results[0]
+    for result in results[1:]:
+        assert result == first_result
+
+    # Verify results are correct
+    assert len(first_result) == len(test_files)
+
+
+def test_cached_remote_filesystem_concurrent_file_access(mock_files):
+    """Test concurrent file access with caching."""
+    # Create mock filesystem
+    mock_fs = MockFileSystem(mock_files)
+    uri = "mock://remote"
+
+    contents = []
+    errors = []
+
+    def worker():
+        try:
+            # Each thread creates its own CachedRemoteFileSystem instance
+            cached_fs = CachedRemoteFileSystem(mock_fs, uri)
+            # Open and read a file
+            with cached_fs.open("/remote/test1.txt", "rb") as f:
+                content = f.read()
+            contents.append(content)
+        except Exception as e:
+            errors.append(e)
+
+    # Create multiple threads
+    threads = [threading.Thread(target=worker) for _ in range(10)]
+
+    # Start all threads
+    for thread in threads:
+        thread.start()
+
+    # Wait for all threads to complete
+    for thread in threads:
+        thread.join()
+
+    # Verify no errors occurred
+    assert len(errors) == 0
+
+    # Verify all threads got content
+    assert len(contents) == 10
+
+    # Verify all contents are identical
+    expected_content = b"Content of test1"
+    for content in contents:
+        assert content == expected_content
+
+
+def test_cached_remote_filesystem_different_uris_separate_caches():
+    """Test that different URIs use separate caches."""
+    # Create two separate mock filesystems
+    test_files1 = {
+        "/uri1/file1.txt": "Content 1A",
+        "/uri1/file2.txt": "Content 1B",
+    }
+    test_files2 = {
+        "/uri2/file1.txt": "Content 2A",
+        "/uri2/file2.txt": "Content 2B",
+        "/uri2/file3.txt": "Content 2C",
+    }
+    mock_fs1 = MockFileSystem(test_files1)
+    mock_fs2 = MockFileSystem(test_files2)
+
+    # Create CachedRemoteFileSystem instances with different URIs
+    uri1 = "mock://uri1"
+    uri2 = "mock://uri2"
+
+    cached_fs1 = CachedRemoteFileSystem(mock_fs1, uri1)
+    cached_fs2 = CachedRemoteFileSystem(mock_fs2, uri2)
+
+    # Each should have called find once
+    assert mock_fs1.find_count == 1
+    assert mock_fs2.find_count == 1
+
+    # Find should return different results
+    result1 = cached_fs1.find("/uri1")
+    result2 = cached_fs2.find("/uri2")
+
+    assert len(result1) == len(test_files1)
+    assert len(result2) == len(test_files2)
+    assert result1 != result2
+
+
+def test_cached_remote_filesystem_proxy_methods():
+    """Test that non-cached methods are properly proxied."""
+    mock_files = {"/remote/test.txt": "Content"}
+    mock_fs = MockFileSystem(mock_files)
+    uri = "mock://remote"
+
+    cached_fs = CachedRemoteFileSystem(mock_fs, uri)
+
+    # Test exists()
+    assert cached_fs.exists("/remote/test.txt")
+    assert not cached_fs.exists("/remote/nonexistent.txt")
+
+    # Test isfile()
+    assert cached_fs.isfile("/remote/test.txt")
+
+
+def test_cache_clear():
+    """Test that clearing the cache removes metadata entries."""
+    test_files = {"/clear_test2/test.txt": "Content"}
+    mock_fs = MockFileSystem(test_files)
+    uri = "mock://clear_test2"
+
+    # Create first instance
+    cached_fs1 = CachedRemoteFileSystem(mock_fs, uri)
+    assert mock_fs.find_count == 1
+
+    # Verify cache has the entry
+    cache = get_remote_fs_cache()
+    assert uri in cache._cache
+
+    # Clear the cache
+    cache.clear()
+
+    # Verify cache metadata is cleared
+    assert uri not in cache._cache

--- a/are/simulation/tests/apps/fallback_filesystem_test.py
+++ b/are/simulation/tests/apps/fallback_filesystem_test.py
@@ -14,6 +14,7 @@ from are.simulation.apps.utils.fallback_file_system import (
     DEFAULT_MODE,
     FallbackFileSystem,
 )
+from are.simulation.apps.utils.remote_fs_cache import get_remote_fs_cache
 
 # Test files to create in the main filesystem and fallback
 TEST_FILES = {
@@ -23,6 +24,25 @@ TEST_FILES = {
     "/docs/readme.md": "# Documentation\nThis is a test markdown file.",
     "/docs/reports/report.txt": "Report content\nWith multiple lines",
 }
+
+
+@pytest.fixture(autouse=True)
+def clear_remote_fs_cache():
+    """Clear the global remote filesystem cache before each test to prevent race conditions."""
+    cache = get_remote_fs_cache()
+    cache.clear()
+    # Also clear the cache storage directory to prevent stale files
+    import shutil
+
+    cache_storage = cache._cache_storage
+    if Path(cache_storage).exists():
+        shutil.rmtree(cache_storage)
+        Path(cache_storage).mkdir(parents=True, exist_ok=True)
+    yield
+    # Clean up after the test as well
+    cache.clear()
+    if Path(cache_storage).exists():
+        shutil.rmtree(cache_storage)
 
 
 @pytest.fixture

--- a/are/simulation/tests/apps/fallback_filesystem_test.py
+++ b/are/simulation/tests/apps/fallback_filesystem_test.py
@@ -70,7 +70,8 @@ def fallback_fs(tmp_path: Path, fallback_dir: Path):
 
     # Set the fallback root (which now automatically creates placeholders)
     expected_paths = set(TEST_FILES.keys())
-    fs.set_fallback_root(f"memory://{fallback_dir}", expected_paths)
+    # Use str(fallback_dir) directly since fallback_dir already has the leading slash
+    fs.set_fallback_root(f"memory:/{fallback_dir}", expected_paths)
 
     return fs, real_dir, fallback_dir
 

--- a/are/simulation/tests/server/session_manager_test.py
+++ b/are/simulation/tests/server/session_manager_test.py
@@ -5,13 +5,15 @@
 # the root directory of this source tree.
 
 
+import time
 from unittest.mock import Mock, patch
 
 import pytest
 
 # Mock the scenarios loading to avoid directory dependency
 with patch(
-    "are.simulation.scenarios.utils.load_utils.load_all_universes", return_value={}
+    "are.simulation.scenarios.utils.load_utils.load_all_universes",
+    return_value={},
 ):
     from are.simulation.gui.server.session_manager import SessionManager
 
@@ -68,6 +70,9 @@ def test_cleanup_inactive_are_simulation():
     mock_are_simulation1 = Mock()
 
     manager.add_are_simulation_instance("test_session", mock_are_simulation1)
+
+    # Wait a small amount to ensure the session becomes inactive
+    time.sleep(0.01)
 
     manager._cleanup_inactive_are_simulation()
 

--- a/are/simulation/types.py
+++ b/are/simulation/types.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from functools import wraps
 from types import MethodType
-from typing import Any, Callable, Literal, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 # Optional strawberry import for GraphQL support
 # When strawberry is not installed, we use no-op decorators
@@ -32,13 +32,11 @@ except ImportError:
 
     # Create no-op decorators when strawberry is not available
     class _StrawberryStub:
-        @staticmethod
-        def enum(cls):
+        def enum(self, cls):
             """No-op decorator when strawberry is not available"""
             return cls
 
-        @staticmethod
-        def type(cls):
+        def type(self, cls):
             """Decorator that converts class to dataclass when strawberry is not available"""
             # Apply dataclass decorator to provide __init__ method
             return dataclass(cls)
@@ -47,7 +45,7 @@ except ImportError:
 
 from are.simulation.priority_queue import PriorityQueue
 from are.simulation.time_manager import TimeManager
-from are.simulation.tool_utils import AppTool, APPTOOL_ATTR_NAME, OperationType
+from are.simulation.tool_utils import APPTOOL_ATTR_NAME, AppTool, OperationType
 from are.simulation.utils import conditional_context_manager, get_function_name
 
 if TYPE_CHECKING:
@@ -136,6 +134,7 @@ class HintType(Enum):
 
 
 @strawberry.type
+@dataclass
 class Hint:
     """
     Hint associated with an event


### PR DESCRIPTION
# 📋 Summary

Bug fix for #19.

The issue is that the fallback filesystem will hit the huggingface hosted filesystem at every scenario and every read. We need to avoid this.

The proposed solution is to add a global cache to cache the reads globally (writes will still be made local by th efallback system)


# 🎯 Type of Change
<!-- Check all that apply -->
- [X ] 🐛 Bug fix (non-breaking change which fixes an issue)

# 🏗️ Meta Agents Research Environments Components Affected
- [ ] **Scenarios** (`are/simulation/scenarios/`, scenario definitions, scenario runner)

# 🔗 Related Issues

#19 


# 🧪 Testing Strategy
<!-- Describe how you tested your changes -->
- [X] **Unit Tests**: Added/updated unit tests
- [X] **Integration Tests**: Tested integration with other components
- [X] **Manual Testing**: Manually verified functionality
- [X] **Scenario Testing**: Ran specific scenarios to validate changes
- [ ] **GUI Testing**: Tested web interface (if applicable)
- [ ] **Regression Testing**: Verified existing functionality still works
