### PR TITLE
[Gaia2-CLI] Fix OpenRouter streaming and reasoning support

### DIFF
--- a/gaia2-cli/containers/openclaw/launch.mjs
+++ b/gaia2-cli/containers/openclaw/launch.mjs
@@ -40,7 +40,7 @@ function traceLog(url, init, status, rawText, latencyMs) {
     latency_ms: latencyMs,
     http_status: status,
     request: requestBody,
-    raw_response: rawText.length > 50000 ? rawText.slice(0, 50000) + "...[truncated]" : rawText,
+    raw_response: rawText,
   };
 
   try {
@@ -123,14 +123,18 @@ globalThis.fetch = async function(url, init) {
     try {
       const reqBody = JSON.parse(init.body);
       let changed = false;
-      if (reqBody.stream) {
+      const isOpenRouter = urlStr.includes("openrouter.ai");
+      if (reqBody.stream && !isOpenRouter) {
         reqBody.stream = false;
         changed = true;
       }
       // Best-effort propagation of the container thinking level to generic
       // OpenAI-compatible chat-completions providers.
       const effort = process.env.REASONING_EFFORT || process.env.THINKING;
-      if (effort && effort !== "none" && effort !== "off" && !reqBody.reasoning) {
+      if (isOpenRouter && effort && effort !== "none" && effort !== "off") {
+        reqBody.reasoning = { enabled: true };
+        changed = true;
+      } else if (effort && effort !== "none" && effort !== "off" && !reqBody.reasoning) {
         reqBody.reasoning = { effort };
         changed = true;
       }

--- a/gaia2-cli/runner/gaia2_runner/trace_parser.py
+++ b/gaia2-cli/runner/gaia2_runner/trace_parser.py
@@ -1076,7 +1076,7 @@ def normalize_entry(entry: dict[str, Any]) -> dict[str, Any]:
     result = dict(entry)
 
     # Detect format: SSE vs plain JSON
-    is_sse = "data: " in raw[:200]
+    is_sse = "data: " in raw[:2000] or raw.lstrip().startswith(": ")
 
     if is_sse:
         events = parse_sse_events(raw)


### PR DESCRIPTION
- Keep stream:true for OpenRouter requests instead of stripping it and reconstructing SSE via completionToSSE. This lets OpenClaw use native streaming and preserves reasoning_details in the response.
- Send reasoning: {enabled: true} for OpenRouter (their documented format) instead of reasoning: {effort: "high"} which is unrecognized.
- Remove 50k char truncation on trace logging so streaming responses are captured in full for the trace viewer.
- Fix SSE detection in trace_parser.py to handle OpenRouter's ": OPENROUTER PROCESSING" comment prefix that pushed data: chunks past the 200-char detection window.

**_Known limitation: OpenRouter returns reasoning_details in responses, but OpenClaw only stores reasoning (plain text) in conversation history. On follow-up turns, reasoning_details is not sent back as OpenRouter recommends. This is an OpenClaw limitation — our code passes the full SSE through untouched. Tracked upstream._**