### PR TITLE
[gaia2-cli] Publish adapter port for Podman on macOS

### DIFF
--- a/gaia2-cli/runner/gaia2_runner/cli.py
+++ b/gaia2-cli/runner/gaia2_runner/cli.py
@@ -58,6 +58,7 @@ SPLIT_DISPLAY_ORDER_INDEX = {
     split_name: index for index, split_name in enumerate(SPLIT_DISPLAY_ORDER)
 }
 DATASET_PARTITION_DIR_NAMES = frozenset({"train", "validation", "test"})
+PORT_ALLOCATION_ATTEMPTS = 1000
 
 
 def _default_env_file() -> Path:
@@ -949,9 +950,27 @@ def _save_dataset_run_config(
     )
 
 
-def _allocate_ports() -> tuple[int, int]:
-    """Allocate unique ephemeral adapter and gateway ports."""
-    return _allocate_free_port(), _allocate_free_port()
+def _allocate_reserved_port(reserved_ports: set[int]) -> int:
+    """Allocate an ephemeral port not already reserved by this runner process."""
+    for _ in range(PORT_ALLOCATION_ATTEMPTS):
+        port = _allocate_free_port()
+        if port not in reserved_ports:
+            reserved_ports.add(port)
+            return port
+
+    raise RuntimeError("Unable to allocate a unique free port")
+
+
+def _allocate_ports(reserved_ports: set[int] | None = None) -> tuple[int, int]:
+    """Allocate unique ephemeral adapter and gateway ports.
+
+    ``reserved_ports`` guards concurrent batches from handing the same released
+    ephemeral port to multiple queued containers in one runner invocation.
+    """
+    ports = reserved_ports if reserved_ports is not None else set()
+    adapter_port = _allocate_reserved_port(ports)
+    gateway_port = _allocate_reserved_port(ports)
+    return adapter_port, gateway_port
 
 
 def _run_scenarios_sequential(
@@ -1010,10 +1029,11 @@ def _run_scenarios_concurrent(
         execution_config.launcher_type,
     )
 
+    reserved_ports: set[int] = set()
     with ThreadPoolExecutor(max_workers=concurrency) as pool:
         futures = {}
         for scenario_path in scenario_paths:
-            adapter_port, gateway_port = _allocate_ports()
+            adapter_port, gateway_port = _allocate_ports(reserved_ports)
             logger.info(
                 "Submitting %s (adapter=%d, gateway=%d)",
                 scenario_path.name,
@@ -1208,10 +1228,11 @@ def _run_interleaved_passes(
         )
         return run_number, result
 
+    reserved_ports: set[int] = set()
     with ThreadPoolExecutor(max_workers=effective_concurrency) as pool:
         futures = {}
         for scenario_path, run_number in all_tasks:
-            adapter_port, gateway_port = _allocate_ports()
+            adapter_port, gateway_port = _allocate_ports(reserved_ports)
             logger.info(
                 "Submitting run_%d/%s (adapter=%d, gateway=%d)",
                 run_number,

--- a/gaia2-cli/runner/gaia2_runner/launcher.py
+++ b/gaia2-cli/runner/gaia2_runner/launcher.py
@@ -14,6 +14,7 @@ import logging
 import os
 import socket
 import subprocess
+import sys
 import threading
 import time
 from abc import ABC, abstractmethod
@@ -391,6 +392,31 @@ class LocalLauncher(ContainerLauncher):
             args, capture_output=True, text=True, check=True, **kwargs
         )
 
+    def _is_podman_runtime(self) -> bool:
+        """Return whether this launcher invokes a Podman CLI."""
+        return any(
+            os.path.basename(part) in {"podman", "podman-remote"} for part in self._rt
+        )
+
+    def _should_publish_adapter_port(
+        self,
+        *,
+        network: str,
+        adapter_port: int | None,
+    ) -> bool:
+        """Use port publishing for local Podman on macOS.
+
+        Podman's ``--network=host`` is the Podman VM's host namespace on
+        macOS, not the macOS host. Publishing the adapter port is what makes
+        ``127.0.0.1:<port>`` reachable from the runner process.
+        """
+        return (
+            sys.platform == "darwin"
+            and self._is_podman_runtime()
+            and network == "host"
+            and adapter_port is not None
+        )
+
     def launch(
         self,
         image: str,
@@ -406,22 +432,28 @@ class LocalLauncher(ContainerLauncher):
         gateway_port: int | None = None,
     ) -> str:
         container_name = self._container_name(scenario_json_path)
+        publish_adapter_port = self._should_publish_adapter_port(
+            network=network,
+            adapter_port=adapter_port,
+        )
 
-        cmd = [
-            *self._rt,
-            "run",
-            "-d",
-            f"--name={container_name}",
-            f"--network={network}",
-            # Workaround for crun seccomp cache permission errors on
-            # some kernels (linkat EPERM in seccomp bpf setup).
-            "--security-opt",
-            "seccomp=unconfined",
-            "-v",
-            f"{scenario_json_path}:/var/gaia2/custom_scenario.json:ro",
-            "--entrypoint",
-            "bash",
-        ]
+        cmd = [*self._rt, "run", "-d", f"--name={container_name}"]
+        if publish_adapter_port:
+            cmd.extend(["-p", f"127.0.0.1:{adapter_port}:{adapter_port}"])
+        else:
+            cmd.append(f"--network={network}")
+        cmd.extend(
+            [
+                # Workaround for crun seccomp cache permission errors on
+                # some kernels (linkat EPERM in seccomp bpf setup).
+                "--security-opt",
+                "seccomp=unconfined",
+                "-v",
+                f"{scenario_json_path}:/var/gaia2/custom_scenario.json:ro",
+                "--entrypoint",
+                "bash",
+            ]
+        )
         for volume in extra_volumes or ():
             cmd.extend(["-v", volume])
 

--- a/gaia2-cli/runner/tests/test_cli_ports.py
+++ b/gaia2-cli/runner/tests/test_cli_ports.py
@@ -1,0 +1,40 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates. All rights reserved.
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from __future__ import annotations
+
+import pytest
+from gaia2_runner import cli as runner_cli
+
+
+def test_allocate_ports_returns_distinct_adapter_and_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidates = iter([41000, 41000, 41001])
+
+    monkeypatch.setattr(runner_cli, "_allocate_free_port", lambda: next(candidates))
+
+    assert runner_cli._allocate_ports() == (41000, 41001)
+
+
+def test_allocate_ports_skips_ports_reserved_by_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidates = iter([41000, 41000, 41001, 41002])
+    reserved_ports = {41000}
+
+    monkeypatch.setattr(runner_cli, "_allocate_free_port", lambda: next(candidates))
+
+    assert runner_cli._allocate_ports(reserved_ports) == (41001, 41002)
+    assert reserved_ports == {41000, 41001, 41002}
+
+
+def test_allocate_ports_raises_after_repeated_reserved_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(runner_cli, "PORT_ALLOCATION_ATTEMPTS", 3)
+    monkeypatch.setattr(runner_cli, "_allocate_free_port", lambda: 41000)
+
+    with pytest.raises(RuntimeError, match="unique free port"):
+        runner_cli._allocate_ports({41000})

--- a/gaia2-cli/runner/tests/test_launcher.py
+++ b/gaia2-cli/runner/tests/test_launcher.py
@@ -51,6 +51,100 @@ def test_local_launcher_adds_extra_volumes(
     assert "/tmp/extra:/tmp/extra" in captured["args"]
 
 
+def test_local_launcher_publishes_adapter_port_for_podman_on_macos(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    scenario_path = tmp_path / "scenario.json"
+    scenario_path.write_text("{}")
+    launcher = LocalLauncher(runtime="podman")
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured["args"] = args
+        return subprocess.CompletedProcess(args, 0, stdout="container-123\n", stderr="")
+
+    monkeypatch.setattr("gaia2_runner.launcher.sys.platform", "darwin")
+    monkeypatch.delenv("GAIA2_PROXY_RELAY_URL", raising=False)
+    monkeypatch.delenv("GAIA2_CA_BUNDLE", raising=False)
+    monkeypatch.setattr("gaia2_runner.launcher.os.path.isfile", lambda _: False)
+    monkeypatch.setattr(launcher, "_run", fake_run)
+
+    launcher.launch(
+        "localhost/gaia2-oracle:latest",
+        str(scenario_path),
+        adapter_port=8123,
+        gateway_port=18790,
+    )
+
+    args = captured["args"]
+    env = _env_map(args)
+    assert "--network=host" not in args
+    assert "-p" in args
+    assert "127.0.0.1:8123:8123" in args
+    assert env["GAIA2_ADAPTER_PORT"] == "8123"
+    assert env["OPENCLAW_GATEWAY_PORT"] == "18790"
+    assert env["OPENCLAW_GATEWAY_URL"] == "ws://127.0.0.1:18790"
+
+
+def test_local_launcher_keeps_host_network_for_podman_on_linux(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    scenario_path = tmp_path / "scenario.json"
+    scenario_path.write_text("{}")
+    launcher = LocalLauncher(runtime="podman")
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured["args"] = args
+        return subprocess.CompletedProcess(args, 0, stdout="container-123\n", stderr="")
+
+    monkeypatch.setattr("gaia2_runner.launcher.sys.platform", "linux")
+    monkeypatch.delenv("GAIA2_PROXY_RELAY_URL", raising=False)
+    monkeypatch.delenv("GAIA2_CA_BUNDLE", raising=False)
+    monkeypatch.setattr("gaia2_runner.launcher.os.path.isfile", lambda _: False)
+    monkeypatch.setattr(launcher, "_run", fake_run)
+
+    launcher.launch(
+        "localhost/gaia2-oracle:latest",
+        str(scenario_path),
+        adapter_port=8123,
+    )
+
+    args = captured["args"]
+    assert "--network=host" in args
+    assert "-p" not in args
+
+
+def test_local_launcher_keeps_explicit_network_for_podman_on_macos(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    scenario_path = tmp_path / "scenario.json"
+    scenario_path.write_text("{}")
+    launcher = LocalLauncher(runtime="podman")
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured["args"] = args
+        return subprocess.CompletedProcess(args, 0, stdout="container-123\n", stderr="")
+
+    monkeypatch.setattr("gaia2_runner.launcher.sys.platform", "darwin")
+    monkeypatch.delenv("GAIA2_PROXY_RELAY_URL", raising=False)
+    monkeypatch.delenv("GAIA2_CA_BUNDLE", raising=False)
+    monkeypatch.setattr("gaia2_runner.launcher.os.path.isfile", lambda _: False)
+    monkeypatch.setattr(launcher, "_run", fake_run)
+
+    launcher.launch(
+        "localhost/gaia2-oracle:latest",
+        str(scenario_path),
+        network="bridge",
+        adapter_port=8123,
+    )
+
+    args = captured["args"]
+    assert "--network=bridge" in args
+    assert "-p" not in args
+
+
 def test_local_launcher_uses_configured_proxy_relay(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

- Publish the Gaia2 adapter port for local Podman on macOS instead of relying on `--network=host`, which points at the Podman VM host namespace rather than the macOS host.
- Preserve the existing `--network=host` behavior for Linux and for non-Podman runtimes, and preserve explicit non-host network selections.
- Reserve unique adapter/gateway ports within concurrent runner batches so high-concurrency runs do not reuse ports already assigned by the parent process.

Fixes #58

## Testing

- `PYTHONPATH=cli:runner:core:. uv run --project runner --python 3.12 --extra dev python -m pytest runner/tests -q`
- `uvx -p3.12 --with flake8-tidy-imports --with flake8 ruff check --select I .`
- `uvx -p3.12 ruff format --check .`
- `git diff --check`
- Local macOS Podman E2E with `localhost/gaia2-oracle:latest`: passed; runner observed adapter status directly from the host.
- Local macOS Podman E2E with `localhost/gaia2-hermes:latest` and Anthropic provider: passed; host `127.0.0.1:<adapter_port>/status` was reachable during the run.